### PR TITLE
Message publish block call fix

### DIFF
--- a/lib/fake_smith.rb
+++ b/lib/fake_smith.rb
@@ -96,7 +96,7 @@ module Smith
 
       def publish(message, &blk)
         FakeSmith.add_message(@queue_name, message)
-        blk.call
+        blk.call if block_given?
       end
 
       def message_count(&blk)


### PR DESCRIPTION
add 'if block_given?' after 'blk.call' in publish method of Sender class
