### PR TITLE
Allow passing opts argument to publish method

### DIFF
--- a/lib/fake_smith.rb
+++ b/lib/fake_smith.rb
@@ -167,7 +167,7 @@ module Smith
       def on_timeout(&blk)
       end
 
-      def publish(message, &blk)
+      def publish(message, opts={}, &blk)
         FakeSmith.add_message(@queue_name, message)
         blk.call if block_given?
         if FakeSmith.reply_handlers[@queue_name] && @on_reply


### PR DESCRIPTION
When publishsing a message, user may want to pass a header to that method too.
Ex: publish(payload, :headers => {:forward_to => "destination_queue"}, &blk)